### PR TITLE
Added timestamps for November 2020 update

### DIFF
--- a/src/Offsets.cpp
+++ b/src/Offsets.cpp
@@ -6,9 +6,9 @@ GameOffsets::GameVersion GameOffsets::getVersion() const {
 	auto dos_header = *reinterpret_cast<IMAGE_DOS_HEADER*>(image_base);
 	auto nt_header = *reinterpret_cast<IMAGE_NT_HEADERS*>((uintptr_t)image_base + dos_header.e_lfanew);
 	int timestamp = nt_header.FileHeader.TimeDateStamp;
-	if (timestamp == 0x5EE9D095)
+	if (timestamp == 0x5EE9D095 || timestamp == 0x5F8D56D3)
 		return GameVersion::DX12;
-	else if (timestamp == 0x5EE9D065)
+	else if (timestamp == 0x5EE9D065 || timestamp == 0x5F8D57CA)
 		return GameVersion::DX11;
 	else
 		return GameVersion::UNK;


### PR DESCRIPTION
Updated `Offsets.cpp` to recognize the November 2020 update of the game for both DX11 and DX12.

I have done some testing with both renderers and everything seems to working fine, but I was far from thorough.