### PR TITLE
Update PE timestamp and offsets for 3.70.0.

### DIFF
--- a/src/Offsets.cpp
+++ b/src/Offsets.cpp
@@ -26,14 +26,14 @@ GameOffsets::GameOffsets() {
         // signature changed introduced with Hitman update 3.30. (Inlining, NPC/WorldItem spawn
         // merge). If the new layout turns out to be stable, sig scanning should be reintroduced.
 
-        // Hitman 3 3.40.1 offsets
-        offsets.pPushItem0 = reinterpret_cast<void*>(0x140D75060);
-        offsets.pPushItem1 = reinterpret_cast<void*>(0x140D75650);
-        offsets.pPushNPCInventoryDetour = reinterpret_cast<void*>(0x14015FF01);
-        offsets.pPushWorldInventoryDetour = reinterpret_cast<void*>(0x140D6F68A);
-        offsets.pPushHeroInventoryDetour = reinterpret_cast<void*>(0x14064C923);
-        offsets.pPushStashInventoryDetour = reinterpret_cast<void*>(0x1403D8074);
-        offsets.pZEntitySceneContext_LoadScene = reinterpret_cast<void**>(0x141D11D20);
+        // Hitman 3 3.70.0 offsets
+        offsets.pPushItem0 = reinterpret_cast<void*>(0x140d7e2f0);
+        offsets.pPushItem1 = reinterpret_cast<void*>(0x140d7e8e0);
+        offsets.pPushNPCInventoryDetour = reinterpret_cast<void*>(0x140166881);
+        offsets.pPushWorldInventoryDetour = reinterpret_cast<void*>(0x140d7891a);
+        offsets.pPushHeroInventoryDetour = reinterpret_cast<void*>(0x140651ed3);
+        offsets.pPushStashInventoryDetour = reinterpret_cast<void*>(0x1403dd954);
+        offsets.pZEntitySceneContext_LoadScene = reinterpret_cast<void**>(0x141d22340);
     } break;
     case GameVersion::H2DX12:
     case GameVersion::H2DX11:

--- a/src/Version.cpp
+++ b/src/Version.cpp
@@ -4,7 +4,7 @@
 
 GameVersion getVersion() {
     auto timestamp = PE::getTimestamp();
-    if(timestamp == 0x60D1D7D0)
+    if(timestamp == 0x6157119F)
         return GameVersion::H3DX12;
     return GameVersion::UNK;
 }


### PR DESCRIPTION
I've never done decompiling but I think I managed to sort out what instructions the offsets are pointing to for the latest EGS release. My fork has a bunch of other implementation work done so I just separated this out if you wanted to pull it in and test it.